### PR TITLE
Fix migration frequency setting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -46,7 +46,10 @@ CROSSOVER_RATE = 0.2
 
 # Island Model Settings
 NUM_ISLANDS = 4  # Number of subpopulations
-MIGRATION_INTERVAL = 4  # Number of generations between migrations
+# Frequency (in generations) at which islands perform migration.
+# This was previously named ``MIGRATION_INTERVAL`` which caused a mismatch with
+# the runtime configuration options.
+MIGRATION_FREQUENCY = 4
 ISLAND_POPULATION_SIZE = POPULATION_SIZE // NUM_ISLANDS  # Programs per island
 MIN_ISLAND_SIZE = 2  # Minimum number of programs per island
 MIGRATION_RATE = 0.2  # Rate at which programs migrate between islands

--- a/selection_controller/agent.py
+++ b/selection_controller/agent.py
@@ -67,7 +67,10 @@ class SelectionControllerAgent(SelectionControllerInterface, BaseAgent):
         super().__init__()
         self.elitism_count = settings.ELITISM_COUNT
         self.num_islands = settings.NUM_ISLANDS
-        self.migration_interval = settings.MIGRATION_INTERVAL
+        # ``settings`` used to expose ``MIGRATION_INTERVAL``.  The rest of the
+        # application (e.g. ``app.py``) refers to ``MIGRATION_FREQUENCY`` so we
+        # mirror that name here.
+        self.migration_frequency = settings.MIGRATION_FREQUENCY
         self.islands: Dict[int, Island] = {}
         self.current_generation = 0
         logger.info(f"SelectionControllerAgent initialized with {self.num_islands} islands and elitism_count: {self.elitism_count}")
@@ -210,7 +213,7 @@ class SelectionControllerAgent(SelectionControllerInterface, BaseAgent):
             island.update_metrics()
 
         # Check if it's time for migration
-        if self.current_generation % self.migration_interval == 0:
+        if self.current_generation % self.migration_frequency == 0:
             if settings.DEBUG:
                 logger.debug(f"Generation {self.current_generation}: Performing migration")
             self._perform_migration()


### PR DESCRIPTION
## Summary
- rename `MIGRATION_INTERVAL` to `MIGRATION_FREQUENCY`
- use new setting throughout selection controller

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*