### PR TITLE
Add task YAML builder to app UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ Thumbs.db
 openalpha_evolve_workflow
 *.dot 
 .gradio
+tasks/


### PR DESCRIPTION
## Summary
- add a function to build and save task YAML files
- keep saved tasks in new `tasks/` directory ignored by git
- enhance UI with a box layout and a *Save Task YAML* button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683b00ef65fc8326bba9658ab718b45d