### PR TITLE
Switch default LLM models to Gemini 2.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,21 @@
 FLASH_API_KEY=API_KEY_FLASH
-FLASH_MODEL=gemini/gemini-2.0-flash
+FLASH_MODEL=gemini/gemini-2.5-flash-preview-05-20
 
-# PRO_API_KEY=API_KEY_PRO
-# PRO_MODEL=gemini/gemini-2.5-pro
+PRO_API_KEY=API_KEY_PRO
+PRO_MODEL=gemini/gemini-2.5-pro
 
 EVALUATION_API_KEY=API_KEY_EVAL
 EVALUATION_MODEL=gpt-4o
 
 # These are optional
 # FLASH_BASE_URL=http://localhost:11434
-# PRO_BASE_URL=your_pro_base_url_if_needed # Commented out as PRO_MODEL is removed
+# PRO_BASE_URL=your_pro_base_url_if_needed
 # EVALUATION_BASE_URL=http://localhost:11434
 
 # --- LiteLLM Configuration ---
 # Default model string for litellm (e.g., "gpt-3.5-turbo", "ollama/mistral", "claude-3-haiku-20240307")
 # See litellm documentation for more model strings: https://docs.litellm.ai/docs/providers
-LITELLM_DEFAULT_MODEL="gemini/gemini-2.0-flash-lite"
+LITELLM_DEFAULT_MODEL="gemini/gemini-2.5-flash-preview-05-20"
 GEMINI_API_KEY=""
 
 # API keys for models accessed via litellm should generally be set as environment variables

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,18 +6,22 @@ load_dotenv()
 # LLM Configuration
 FLASH_API_KEY = os.getenv("FLASH_API_KEY")
 FLASH_BASE_URL = os.getenv("FLASH_BASE_URL", None)
-FLASH_MODEL = os.getenv("FLASH_MODEL")
+# Default to the Gemini 2.5 flash 05-20 preview model if not provided
+FLASH_MODEL = os.getenv("FLASH_MODEL", "gemini/gemini-2.5-flash-preview-05-20")
 
-# PRO_API_KEY = os.getenv("PRO_API_KEY")
-# PRO_BASE_URL = os.getenv("PRO_BASE_URL", None)
-# PRO_MODEL = os.getenv("PRO_MODEL")
+# Primary "pro" model configuration. These were previously commented out but are
+# now loaded so they can be used as the primary model if desired.
+PRO_API_KEY = os.getenv("PRO_API_KEY")
+PRO_BASE_URL = os.getenv("PRO_BASE_URL", None)
+PRO_MODEL = os.getenv("PRO_MODEL", "gemini/gemini-2.5-pro")
 
 EVALUATION_API_KEY = os.getenv("EVALUATION_API_KEY")
 EVALUATION_BASE_URL = os.getenv("EVALUATION_BASE_URL", None)
 EVALUATION_MODEL = os.getenv("EVALUATION_MODEL")
 
 # LiteLLM Configuration
-LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", "gpt-3.5-turbo")
+# Use the Gemini 2.5 flash model by default for all LiteLLM calls
+LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", FLASH_MODEL)
 LITELLM_DEFAULT_BASE_URL = os.getenv("LITELLM_DEFAULT_BASE_URL", None)
 LITELLM_MAX_TOKENS = int(os.getenv("LITELLM_MAX_TOKENS"))
 LITELLM_TEMPERATURE = float(os.getenv("LITELLM_TEMPERATURE"))
@@ -25,8 +29,9 @@ LITELLM_TOP_P = float(os.getenv("LITELLM_TOP_P"))
 LITELLM_TOP_K = int(os.getenv("LITELLM_TOP_K"))
 
 # Specific model names for strategic use (can be same as LITELLM_DEFAULT_MODEL if only one is used)
-LLM_PRIMARY_MODEL = os.getenv("LLM_PRIMARY_MODEL", LITELLM_DEFAULT_MODEL)
-LLM_SECONDARY_MODEL = os.getenv("LLM_SECONDARY_MODEL", FLASH_MODEL if FLASH_MODEL else LLM_PRIMARY_MODEL)
+# Primary model defaults to Gemini 2.5 Pro while secondary uses the flash variant
+LLM_PRIMARY_MODEL = os.getenv("LLM_PRIMARY_MODEL", PRO_MODEL)
+LLM_SECONDARY_MODEL = os.getenv("LLM_SECONDARY_MODEL", FLASH_MODEL)
 
 # if not PRO_API_KEY:
 #     print("Warning: PRO_API_KEY not found in .env or environment. Using a NON-FUNCTIONAL placeholder. Please create a .env file with your valid API key.")


### PR DESCRIPTION
## Summary
- default flash model now `gemini/gemini-2.5-flash-preview-05-20`
- load Gemini Pro configuration and use it as the primary model
- update `.env.example` to show the new defaults

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_683b0103e174832696b9cdead6c69a59