### PR TITLE
Fix dotenv dependency handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,13 @@ import sys
 import time
 import logging
 from datetime import datetime
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback for environments without python-dotenv
+    def load_dotenv(*args, **kwargs):
+        """Fallback no-op if python-dotenv is not installed."""
+        return False
 import yaml
 
                                                

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,11 @@
 import os
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback for environments without python-dotenv
+    def load_dotenv(*args, **kwargs):
+        """Fallback no-op if python-dotenv is not installed."""
+        return False
 
 load_dotenv()
 
@@ -19,10 +25,10 @@ EVALUATION_MODEL = os.getenv("EVALUATION_MODEL")
 # LiteLLM Configuration
 LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", "gpt-3.5-turbo")
 LITELLM_DEFAULT_BASE_URL = os.getenv("LITELLM_DEFAULT_BASE_URL", None)
-LITELLM_MAX_TOKENS = int(os.getenv("LITELLM_MAX_TOKENS"))
-LITELLM_TEMPERATURE = float(os.getenv("LITELLM_TEMPERATURE"))
-LITELLM_TOP_P = float(os.getenv("LITELLM_TOP_P"))
-LITELLM_TOP_K = int(os.getenv("LITELLM_TOP_K"))
+LITELLM_MAX_TOKENS = int(os.getenv("LITELLM_MAX_TOKENS", "4096"))
+LITELLM_TEMPERATURE = float(os.getenv("LITELLM_TEMPERATURE", "1.0"))
+LITELLM_TOP_P = float(os.getenv("LITELLM_TOP_P", "0.9"))
+LITELLM_TOP_K = int(os.getenv("LITELLM_TOP_K", "40"))
 
 # Specific model names for strategic use (can be same as LITELLM_DEFAULT_MODEL if only one is used)
 LLM_PRIMARY_MODEL = os.getenv("LLM_PRIMARY_MODEL", LITELLM_DEFAULT_MODEL)


### PR DESCRIPTION
## Summary
- handle missing `python-dotenv` gracefully in `config/settings.py` and `app.py`
- provide default configuration values when environment variables are unset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b023f54a48326b6bc990f3703050c