### PR TITLE
Fix Gemini auth if GOOGLE_API_KEY missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ EVALUATION_MODEL=gpt-4o
 # See litellm documentation for more model strings: https://docs.litellm.ai/docs/providers
 LITELLM_DEFAULT_MODEL="gemini/gemini-2.5-flash-preview-05-20"
 GEMINI_API_KEY=""
+# If GOOGLE_API_KEY or GEMINI_API_KEY is not explicitly provided,
+# the application will fall back to FLASH_API_KEY or PRO_API_KEY
+# to authenticate Gemini calls via LiteLLM.
 
 # API keys for models accessed via litellm should generally be set as environment variables
 # that litellm recognizes (e.g., OPENAI_API_KEY, COHERE_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ OpenAlpha_Evolve employs a modular, agent-based architecture to orchestrate an e
         cp .env_example .env
         ```
 
+    * If you set `FLASH_API_KEY` or `PRO_API_KEY` but do not provide
+      `GOOGLE_API_KEY`, the application will automatically reuse those keys for
+      Gemini models.
+
 
 ### LLM Configuration
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -25,6 +25,15 @@ EVALUATION_API_KEY = os.getenv("EVALUATION_API_KEY")
 EVALUATION_BASE_URL = os.getenv("EVALUATION_BASE_URL", None)
 EVALUATION_MODEL = os.getenv("EVALUATION_MODEL")
 
+# Ensure litellm sees a valid Gemini API key. It checks the environment for
+# ``GOOGLE_API_KEY`` or ``GEMINI_API_KEY``. If neither is set but one of our
+# custom keys is, fall back to it so that calls to the Gemini models succeed.
+if not os.getenv("GOOGLE_API_KEY") and not os.getenv("GEMINI_API_KEY"):
+    if FLASH_API_KEY:
+        os.environ["GOOGLE_API_KEY"] = FLASH_API_KEY
+    elif PRO_API_KEY:
+        os.environ["GOOGLE_API_KEY"] = PRO_API_KEY
+
 # LiteLLM Configuration
 # Use the Gemini 2.5 flash model by default for all LiteLLM calls
 LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", FLASH_MODEL)


### PR DESCRIPTION
## Summary
- default GOOGLE_API_KEY to FLASH_API_KEY or PRO_API_KEY
- document fallback behaviour in `.env.example`
- clarify environment variable note in README

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_b_683beca7c1c883268c9d6c2ec9bff0af